### PR TITLE
Fix calling kscript.bat by symlink and PowerShell compatibility

### DIFF
--- a/src/kscript.bat
+++ b/src/kscript.bat
@@ -55,7 +55,7 @@ rem ##########################################################################
 rem # subroutines
 
 :set_home
-  set _BIN_DIR=%~dp0
+  set _BIN_DIR=%~dps0
   set _KOTLIN_HOME=%_BIN_DIR%..
 goto :eof
 

--- a/src/kscript.bat
+++ b/src/kscript.bat
@@ -45,8 +45,7 @@ if !_java_major_version! geq 9 (
   set JAVA_OPTS=!JAVA_OPTS! "--add-opens" "java.base/java.util=ALL-UNNAMED"
 )
 
-for /f "tokens=* USEBACKQ" %%o in (`where kscript.bat`) do set ABS_KSCRIPT_PATH=%%o
-set CLASS_PATH=%ABS_KSCRIPT_PATH:~0,-16%\bin\*
+set CLASS_PATH=%_BIN_DIR%\*
 
 java !JAVA_OPTS! -classpath %CLASS_PATH% io.github.kscripting.kscript.KscriptKt windows %KOTLIN_OPTS%
 
@@ -56,8 +55,7 @@ rem ##########################################################################
 rem # subroutines
 
 :set_home
-  set _BIN_DIR=
-  for %%i in (%~sf0) do set _BIN_DIR=%_BIN_DIR%%%~dpsi
+  set _BIN_DIR=%~dp0
   set _KOTLIN_HOME=%_BIN_DIR%..
 goto :eof
 


### PR DESCRIPTION
The scenario:
1. Unpack kscript files to a folder which is not in the PATH
2. Make a symlink to kscript.bat
3. Run `kscript "println('1')"` in cmd or `kscript """println('1')"""` in PowerShell.

You will get the following error:
```
Error: Could not find or load main class io.github.kscripting.kscript.KscriptKt
Caused by: java.lang.ClassNotFoundException: io.github.kscripting.kscript.KscriptKt
```

The reason is that kscript.bat strictly depends on kscript.bat being in your PATH. It uses `where` (`where.exe` from `System32`)  to locate the kscript.bat in the PATH. 

Another problem with this approach is that when executed in PowerShell,  `where` becomes an alias to the `Where-Object` PowerShell function, which returns an empty string.
 
The provided solution both makes symlinks work and fixes compatibility with PowerShell.