### PR TITLE
quote kotlinc path on windows (fixes #397)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -308,7 +308,7 @@ dependencies {
     implementation("net.igsoft:tablevis:0.6.0")
     implementation("io.arrow-kt:arrow-core:1.1.2")
 
-    implementation("io.github.kscripting:shell:0.5.0")
+    implementation("io.github.kscripting:shell:0.5.1")
 
     implementation("org.slf4j:slf4j-nop:2.0.5")
 

--- a/src/main/kotlin/io/github/kscripting/kscript/resolver/CommandResolver.kt
+++ b/src/main/kotlin/io/github/kscripting/kscript/resolver/CommandResolver.kt
@@ -137,12 +137,7 @@ class CommandResolver(val osConfig: OsConfig) {
             osConfig.kotlinHomeDir.resolve("bin", if (osConfig.osType.isWindowsLike()) "$binary.bat" else binary)
                 .convert(osConfig.osType)
                 .stringPath()
-        return if (osConfig.osType == OsType.WINDOWS) {
-            // if the first character in args in `cmd /c <args>` is a quote, cmd will remove it as well as the
-            // last quote character within args before processing the term, which removes our quotes.
-            " ${filePathQuotationMark}${pathToKotlinc}${filePathQuotationMark}"
-        } else {
-            pathToKotlinc
-        }
+        val quotes = if (osConfig.osType == OsType.WINDOWS) filePathQuotationMark else ""
+        return "${quotes}${pathToKotlinc}${quotes}"
     }
 }

--- a/src/main/kotlin/io/github/kscripting/kscript/resolver/CommandResolver.kt
+++ b/src/main/kotlin/io/github/kscripting/kscript/resolver/CommandResolver.kt
@@ -12,6 +12,12 @@ class CommandResolver(val osConfig: OsConfig) {
     private val classPathSeparator =
         if (osConfig.osType.isWindowsLike() || osConfig.osType.isPosixHostedOnWindows()) ";" else ":"
 
+    private val filePathQuotationMark = when (osConfig.osType) {
+        OsType.WINDOWS -> '"'
+        else -> '\''
+    }
+
+
     fun getKotlinJreVersion(): String {
         val kotlin = resolveKotlinBinary("kotlin")
         return "$kotlin -version"
@@ -90,41 +96,23 @@ class CommandResolver(val osConfig: OsConfig) {
     private fun resolveKotlinOpts(kotlinOpts: Set<KotlinOpt>) = kotlinOpts.joinToString(" ") { it.value }
 
     private fun resolveCompilerOpts(compilerOpts: Set<CompilerOpt>) = compilerOpts.joinToString(" ") { it.value }
-
     private fun resolveJarFile(jar: OsPath): String {
-        val jarFileQuotationMark: Char = when (osConfig.osType) {
-            OsType.WINDOWS -> '"'
-            else -> '\''
-        }
-
-        return "${jarFileQuotationMark}${resolveQuotedPath(jar)}${jarFileQuotationMark}"
+        return "${filePathQuotationMark}${resolveQuotedPath(jar)}${filePathQuotationMark}"
     }
 
     private fun resolveFiles(filePaths: Set<OsPath>): String {
-        val filePathQuotationMark: Char = when (osConfig.osType) {
-            OsType.WINDOWS -> '"'
-            else -> '\''
-        }
-
         return filePaths.joinToString(" ") {
-            "${filePathQuotationMark}${
-                resolveQuotedPath(it)
-            }${filePathQuotationMark}"
+            "${filePathQuotationMark}${resolveQuotedPath(it)}${filePathQuotationMark}"
         }
     }
 
     private fun resolveUserArgs(userArgs: List<String>): String {
-        val userArgQuotationMark: Char = when (osConfig.osType) {
-            OsType.WINDOWS -> '"'
-            else -> '\''
-        }
-
         return userArgs.joinToString(" ") {
-            "${userArgQuotationMark}${
+            "${filePathQuotationMark}${
                 it.replace(
                     "\"", "\\\""
                 )
-            }${userArgQuotationMark}"
+            }${filePathQuotationMark}"
         }
     }
 
@@ -133,14 +121,11 @@ class CommandResolver(val osConfig: OsConfig) {
             return ""
         }
 
-        val classpathParameterQuotationMark: Char = when (osConfig.osType) {
-            OsType.WINDOWS -> '"'
-            else -> '\''
-        }
-
-        val classpath = classpathParameterQuotationMark + dependencies.joinToString(classPathSeparator) {
-            resolveQuotedPath(it)
-        } + classpathParameterQuotationMark
+        val classpath = "${filePathQuotationMark}${
+            dependencies.joinToString(classPathSeparator) {
+                resolveQuotedPath(it)
+            }
+        }${filePathQuotationMark}"
 
         return "-classpath $classpath"
     }
@@ -148,8 +133,16 @@ class CommandResolver(val osConfig: OsConfig) {
     private fun resolveQuotedPath(osPath: OsPath): String = osPath.toNativeOsPath().stringPath()
 
     private fun resolveKotlinBinary(binary: String): String {
-        return osConfig.kotlinHomeDir.resolve("bin", if (osConfig.osType.isWindowsLike()) "$binary.bat" else binary)
-            .convert(osConfig.osType)
-            .stringPath()
+        val pathToKotlinc =
+            osConfig.kotlinHomeDir.resolve("bin", if (osConfig.osType.isWindowsLike()) "$binary.bat" else binary)
+                .convert(osConfig.osType)
+                .stringPath()
+        return if (osConfig.osType == OsType.WINDOWS) {
+            // if the first character in args in `cmd /c <args>` is a quote, cmd will remove it as well as the
+            // last quote character within args before processing the term, which removes our quotes.
+            " ${filePathQuotationMark}${pathToKotlinc}${filePathQuotationMark}"
+        } else {
+            pathToKotlinc
+        }
     }
 }

--- a/src/test/kotlin/io/github/kscripting/kscript/resolver/CommandResolverTest.kt
+++ b/src/test/kotlin/io/github/kscripting/kscript/resolver/CommandResolverTest.kt
@@ -23,11 +23,11 @@ class CommandResolverTest {
         val commandResolver = CommandResolver(config.osConfig)
 
         assertThat(commandResolver.compileKotlin(jarPath, depPaths, filePaths, compilerOpts)).isEqualTo(
-            """ "C:\Users\Admin With Spaces\scoop\apps\kotlin\current\bin\kotlinc.bat" -abc -def --experimental -classpath "C:\My Workspace\Code\.m2\somepath\dep1.jar;C:\My Workspace\Code\.m2\somepath\dep2.jar;C:\My Workspace\Code\.m2\somepath\dep3.jar" -d "C:\My Workspace\Code\.kscript\cache\somefile.jar" "C:\My Workspace\Code\source\somepath\dep1.kt" "C:\My Workspace\Code\source\somepath\dep2.kts""""
+            """"C:\Users\Admin With Spaces\scoop\apps\kotlin\current\bin\kotlinc.bat" -abc -def --experimental -classpath "C:\My Workspace\Code\.m2\somepath\dep1.jar;C:\My Workspace\Code\.m2\somepath\dep2.jar;C:\My Workspace\Code\.m2\somepath\dep3.jar" -d "C:\My Workspace\Code\.kscript\cache\somefile.jar" "C:\My Workspace\Code\source\somepath\dep1.kt" "C:\My Workspace\Code\source\somepath\dep2.kts""""
         )
 
         assertThat(commandResolver.executeKotlin(jarArtifact, depPaths, userArgs, kotlinOpts)).isEqualTo(
-            """ "C:\Users\Admin With Spaces\scoop\apps\kotlin\current\bin\kotlin.bat" -k1 -k2 --disable -classpath "C:\My Workspace\Code\.m2\somepath\dep1.jar;C:\My Workspace\Code\.m2\somepath\dep2.jar;C:\My Workspace\Code\.m2\somepath\dep3.jar;C:\My Workspace\Code\.kscript\cache\somefile.jar;C:\Users\Admin With Spaces\scoop\apps\kotlin\current\lib\kotlin-script-runtime.jar" mainClass "arg" "u" "ments""""
+            """"C:\Users\Admin With Spaces\scoop\apps\kotlin\current\bin\kotlin.bat" -k1 -k2 --disable -classpath "C:\My Workspace\Code\.m2\somepath\dep1.jar;C:\My Workspace\Code\.m2\somepath\dep2.jar;C:\My Workspace\Code\.m2\somepath\dep3.jar;C:\My Workspace\Code\.kscript\cache\somefile.jar;C:\Users\Admin With Spaces\scoop\apps\kotlin\current\lib\kotlin-script-runtime.jar" mainClass "arg" "u" "ments""""
         )
     }
 

--- a/src/test/kotlin/io/github/kscripting/kscript/resolver/CommandResolverTest.kt
+++ b/src/test/kotlin/io/github/kscripting/kscript/resolver/CommandResolverTest.kt
@@ -18,16 +18,16 @@ class CommandResolverTest {
         val (config, jarPath, jarArtifact, depPaths, filePaths) = createTestData(
             OsType.WINDOWS,
             "C:\\My Workspace\\Code",
-            "C:\\Users\\Admin\\scoop\\apps\\kotlin\\current"
+            "C:\\Users\\Admin With Spaces\\scoop\\apps\\kotlin\\current"
         )
         val commandResolver = CommandResolver(config.osConfig)
 
         assertThat(commandResolver.compileKotlin(jarPath, depPaths, filePaths, compilerOpts)).isEqualTo(
-            """C:\Users\Admin\scoop\apps\kotlin\current\bin\kotlinc.bat -abc -def --experimental -classpath "C:\My Workspace\Code\.m2\somepath\dep1.jar;C:\My Workspace\Code\.m2\somepath\dep2.jar;C:\My Workspace\Code\.m2\somepath\dep3.jar" -d "C:\My Workspace\Code\.kscript\cache\somefile.jar" "C:\My Workspace\Code\source\somepath\dep1.kt" "C:\My Workspace\Code\source\somepath\dep2.kts""""
+            """ "C:\Users\Admin With Spaces\scoop\apps\kotlin\current\bin\kotlinc.bat" -abc -def --experimental -classpath "C:\My Workspace\Code\.m2\somepath\dep1.jar;C:\My Workspace\Code\.m2\somepath\dep2.jar;C:\My Workspace\Code\.m2\somepath\dep3.jar" -d "C:\My Workspace\Code\.kscript\cache\somefile.jar" "C:\My Workspace\Code\source\somepath\dep1.kt" "C:\My Workspace\Code\source\somepath\dep2.kts""""
         )
 
         assertThat(commandResolver.executeKotlin(jarArtifact, depPaths, userArgs, kotlinOpts)).isEqualTo(
-            """C:\Users\Admin\scoop\apps\kotlin\current\bin\kotlin.bat -k1 -k2 --disable -classpath "C:\My Workspace\Code\.m2\somepath\dep1.jar;C:\My Workspace\Code\.m2\somepath\dep2.jar;C:\My Workspace\Code\.m2\somepath\dep3.jar;C:\My Workspace\Code\.kscript\cache\somefile.jar;C:\Users\Admin\scoop\apps\kotlin\current\lib\kotlin-script-runtime.jar" mainClass "arg" "u" "ments""""
+            """ "C:\Users\Admin With Spaces\scoop\apps\kotlin\current\bin\kotlin.bat" -k1 -k2 --disable -classpath "C:\My Workspace\Code\.m2\somepath\dep1.jar;C:\My Workspace\Code\.m2\somepath\dep2.jar;C:\My Workspace\Code\.m2\somepath\dep3.jar;C:\My Workspace\Code\.kscript\cache\somefile.jar;C:\Users\Admin With Spaces\scoop\apps\kotlin\current\lib\kotlin-script-runtime.jar" mainClass "arg" "u" "ments""""
         )
     }
 


### PR DESCRIPTION
As explained in #397 and here https://stackoverflow.com/a/356014/1907778 `cmd /c` has problems with spaces in paths, which normally can be corrected in cmd / bat using double quotes. But if using some argument with `cmd /c <argument>`, the behavior is special for backwards compatibility if the first character is a double quote, in which case it will remove this first character as well as the last double quote in the argument, completely breaking the existing quotations.

Alternatives I have not taken:
* You could use path segment wise quotation like `C:\"my folder"\"my subfolder"\kotlinc.bat`. This seemed to be a too invasive use.
* Instead of using absolute paths, just set the ProcessBuilder's `directory` to kotlinc's parent dir, and call it with a relative path. Cleanest solution, but biggest change (and might split up the code pathways too much).
* Directly call the kotlinc executable without `cmd /c <path>` indirection. Context under windows and pwd should still be fine on any NT version or newer.
* Call powershell instead of cmd to trampoline commands. Probably more stable, but adds in additional tech and complexity for little gain.


Instead, this PR just prefixes the quoted path with a space character, disabling this special cmd mode. The now also quoted path is read in correctly, even if it contains spaces. A prefixed space outside quotation marks is effectively ignored even in cmd's command mode. Because this workaround is only needed on Windows while using cmd, it's using an if.

Because there would now be 5 identical `when` expressions in the class to determine which quotes to use, as well as two different string concatenations, both have been simplified into a simple `val` and template interpolation on all 5 instances. 


I might oversee some edge case, so any pointers would be more than welcome.