### PR TITLE
Fix and expand manual tests with auth repo

### DIFF
--- a/test/TestsReadme.md
+++ b/test/TestsReadme.md
@@ -160,11 +160,11 @@ As of this writing, testing the credentials is only done manually with a dockeri
 docker run --name artifactory -d -p 8081:8081 docker.bintray.io/jfrog/artifactory-oss:latest
 
 # Copy preconfigured gloabl config (with custom repo) and security config (with credentials user) into container.
-docker cp ./test/resources/artifactory_config/artifactory.config.xml artifactory:/var/opt/jfrog/artifactory/etc/artifactory.config.import.xml
-docker cp ./test/resources/artifactory_config/security_descriptor.xml artifactory:/var/opt/jfrog/artifactory/etc/security.import.xml
+docker cp ./test/resources/artifactory_config/artifactory.config.xml artifactory:/var/opt/jfrog/artifactory/etc/artifactory/artifactory.config.import.xml
+docker cp ./test/resources/artifactory_config/security_descriptor.xml artifactory:/var/opt/jfrog/artifactory/etc/artifactory/security.import.xml
 
 # Make the configs accessable
-docker exec -u 0 -it artifactory sh -c 'chmod 777 $ARTIFACTORY_HOME/etc/*.import.xml'
+docker exec -u 0 -it artifactory sh -c 'chmod 777 /var/opt/jfrog/artifactory/etc/artifactory/*.import.xml'
 
 # Restart docker after is done with initial booting (otherwise restart breaks the container).
 echo "sleeping for 15..." && sleep 15
@@ -189,7 +189,35 @@ echo '
 @file:DependsOn("com.jcabi:jcabi-aether:0.10.1") // If unencrypted works via jcenter
 @file:DependsOnMaven("group:somejar:1.0") // If encrypted works.
 println("Hello, World!")
-' |  kscript -
+' |  kscript -c -
+```
+
+#### 4. Test environment variable substitution
+
+```bash
+export auth_user="auth_user"
+export auth_password="password"
+
+echo '
+@file:Repository("http://localhost:8081/artifactory/authenticated_repo", user="{{auth_user}}", password="{{auth_password}}")
+@file:DependsOn("com.jcabi:jcabi-aether:0.10.1") // If unencrypted works via jcenter
+@file:DependsOnMaven("group:somejar:1.0") // If encrypted works.
+println("Hello, World!")
+' |  kscript -c -
+```
+
+#### 5. Test environment variable substitution with packaging
+
+```bash
+export auth_user="auth_user"
+export auth_password="password"
+
+echo '
+@file:Repository("http://localhost:8081/artifactory/authenticated_repo", user="{{auth_user}}", password="{{auth_password}}")
+@file:DependsOn("com.jcabi:jcabi-aether:0.10.1") // If unencrypted works via jcenter
+@file:DependsOnMaven("group:somejar:1.0") // If encrypted works.
+println("Hello, World!")
+' |  kscript -c --package -
 ```
 
 ### Additional info for manual testing


### PR DESCRIPTION
The manual tests for an authenticated repo were not complete.

Fixed the test artifactory server startup.

Added a test for environment variable substitution (test 4). Note that this test follows the current documentation in the README of using `{{FOO}}` style env var substitutions, but that will not currently work. What will work is `$FOO`. This should be updated as part of the fix for https://github.com/kscripting/kscript/issues/402.

Added a test for environment variable substitution with packaging (test 5). This test will not currently work as the substituted credentials are not passed to Gradle properly by kscript.

NOTE: Instead of this being a manual test, it could be done in an automated unit test with Testcontainers.